### PR TITLE
Fix with_items "bare variables" error

### DIFF
--- a/tasks/CentOS.yml
+++ b/tasks/CentOS.yml
@@ -3,5 +3,5 @@
 
 - name: Install unzip packages
   yum: name={{ item }} state=present
-  with_items: unzip_packages
+  with_items: "{{ unzip_packages }}"
   tags: unzip

--- a/tasks/Ubuntu.yml
+++ b/tasks/Ubuntu.yml
@@ -3,5 +3,5 @@
 
 - name: Install unzip packages
   apt: name={{ item }} state=present update_cache=yes
-  with_items: unzip_packages
+  with_items: "{{ unzip_packages }}"
   tags: unzip


### PR DESCRIPTION
```
TASK [kbrebanov.unzip : Install unzip packages] ********************************
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks
 so that the environment value uses the full variable syntax
('{{unzip_packages}}'). This feature will be removed in a future release.
Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.
```

Bare variables in a `with_items` clause were allowed in 1.9 but not in 2.x

This causes CI errors like https://travis-ci.org/kbrebanov/ansible-vault/builds/117505794
